### PR TITLE
Corrected /data mount point detection in disk statistics

### DIFF
--- a/.local/bin/rxfetch
+++ b/.local/bin/rxfetch
@@ -79,7 +79,13 @@ function getMemoryUsage() {
 }
 
 function getDiskUsage() {
-  _MOUNTED_ON="/data"
+  dir=$(df -h | grep '/data' | grep -v 'overlay' | awk '{print $6}')
+
+  if [ -z "$dir" ]; then
+      dir="storage/emulated"
+  fi
+
+  _MOUNTED_ON="$dir"
   _GREP_ONE_ROW="$(df -h | grep ${_MOUNTED_ON})"
   _SIZE="$(echo ${_GREP_ONE_ROW} | awk '{print $2}')"
   _USED="$(echo ${_GREP_ONE_ROW} | awk '{print $3}')"

--- a/.local/bin/rxfetch
+++ b/.local/bin/rxfetch
@@ -46,16 +46,16 @@ function getKernel() {
 function getTotalPackages() {
   package_manager="$(which {apt,dpkg} 2>/dev/null | grep -v "not found" | awk -F/ 'NR==1{print $NF}')"
   case "${package_manager}" in
-    "apt" )
-      packages=$(apt list --installed 2>/dev/null | wc -l)
+  "apt")
+    packages=$(apt list --installed 2>/dev/null | wc -l)
     ;;
-    
-    "dpkg" )
-      packages=$(dpkg-query -l | wc -l)
+
+  "dpkg")
+    packages=$(dpkg-query -l | wc -l)
     ;;
-    
-    "" )
-      packages="Unknown"
+
+  "")
+    packages="Unknown"
     ;;
   esac
 }
@@ -124,5 +124,3 @@ echo -e "\n\n"
 #echo -e "     oo|       "
 #echo -e "    / '\'"
 #echo -e "   (\_;/)"
-
-


### PR DESCRIPTION

Disk statistics were not working correctly on my device. After investigating the issue, I noticed that `/data` was missing from the list of mount points. However, there was a match with `/product/data-app`, which likely caused the error.  

Example output from the `df -h` command:  
```shell
  overlay                             12K  12K     0 100%  /product/data-app
  /dev/fuse                          475G 138G  337G  30%  /storage/emulated
```  
To fix this, I modified the mount point detection logic for `/data`, ensuring that any incorrect matches with `overlay` are excluded and setting a default value if `/data` is not found.  

### **Code Changes:**  
```shell
  dir=$(df -h | grep '/data' | grep -v 'overlay' | awk '{print $6}')

  if [ -z "$dir" ]; then
      dir="storage/emulated"
  fi
  _MOUNTED_ON="$dir"
```  

With this change, `/data` mount point detection is more accurate and should prevent issues on devices where `/data` does not appear directly in the `df -h` output. This could solve the issue #76 

Attached is a screenshot showing the detected issue:  
![Screenshot_2025-02-14-22-03-19-549_com termux](https://github.com/user-attachments/assets/6ce26078-f4cf-45af-908b-2d7e56c611f1)