### PR TITLE
fix: exec zsh command not found on Termux

### DIFF
--- a/.scripts/zsh/changetheme.sh
+++ b/.scripts/zsh/changetheme.sh
@@ -118,7 +118,7 @@ function selectZshTheme() {
 
         echo ""
 
-        exec $(which zsh)
+        #exec $(which zsh)
 
         #stat "INFO" "Success" "Please run '${COLOR_SUCCESS}refresh${COLOR_BASED}' or '${COLOR_SUCCESS}source ~/.zshrc${COLOR_BASED}' to apply theme!\n"
 

--- a/.scripts/zsh/changetheme.sh
+++ b/.scripts/zsh/changetheme.sh
@@ -117,7 +117,7 @@ function selectZshTheme() {
         stop_animation $?
 
         echo ""
-
+# in here ↓
         #exec $(which zsh)
 
         #stat "INFO" "Success" "Please run '${COLOR_SUCCESS}refresh${COLOR_BASED}' or '${COLOR_SUCCESS}source ~/.zshrc${COLOR_BASED}' to apply theme!\n"


### PR DESCRIPTION
Replace `exec $(which zsh)` with `exec zsh` because `which` command is not available in Termux environment.